### PR TITLE
fix: 修复web崩溃 采用log.Println代替log.Fatalln

### DIFF
--- a/cmd/web/controller/comment.go
+++ b/cmd/web/controller/comment.go
@@ -34,7 +34,7 @@ func CommentAction(ctx context.Context, c *app.RequestContext) {
 
 	resp, err := rpc.UserCommentAction(context.Background(), &feedReq)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		return
 	}
 	c.JSON(http.StatusOK, resp)
@@ -46,7 +46,7 @@ func CommentList(ctx context.Context, c *app.RequestContext) {
 	feedReq.VideoId, _ = strconv.ParseInt(c.Query("video_id"), 10, 64)
 	resp, err := rpc.UserCommentList(context.Background(), &feedReq)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		return
 	}
 	c.JSON(http.StatusOK, resp)

--- a/cmd/web/controller/favorite.go
+++ b/cmd/web/controller/favorite.go
@@ -19,7 +19,7 @@ func FavoriteAction(ctx context.Context, c *app.RequestContext) {
 	feedReq.Token = c.Query("token")
 	resp, err := rpc.UserFavoriteAction(context.Background(), &feedReq)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		return
 	}
 	c.JSON(http.StatusOK, resp)
@@ -31,7 +31,7 @@ func FavoriteList(ctx context.Context, c *app.RequestContext) {
 	feedReq.UserId, _ = strconv.ParseInt(c.Query("user_id"), 10, 64)
 	resp, err := rpc.UserFavoriteList(context.Background(), &feedReq)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		return
 	}
 	c.JSON(http.StatusOK, resp)

--- a/cmd/web/controller/publish.go
+++ b/cmd/web/controller/publish.go
@@ -60,7 +60,7 @@ func Publish(ctx context.Context, c *app.RequestContext) {
 	userPublishActionReq.Token = token
 	resp, err := rpc.UserPublishAction(context.Background(), &userPublishActionReq)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		return
 	}
 	c.JSON(http.StatusOK, resp)
@@ -75,7 +75,7 @@ func PublishList(ctx context.Context, c *app.RequestContext) {
 	userPublishListReq.UserId, _ = strconv.ParseInt(userID, 10, 64)
 	resp, err := rpc.UserPublishList(context.Background(), &userPublishListReq)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		return
 	}
 	c.JSON(http.StatusOK, resp)

--- a/cmd/web/controller/relation.go
+++ b/cmd/web/controller/relation.go
@@ -24,7 +24,7 @@ func RelationAction(ctx context.Context, c *app.RequestContext) {
 	feedReq.ActionType = int32(actionType)
 	resp, err := rpc.UserRelationAction(context.Background(), &feedReq)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		return
 	}
 	c.JSON(http.StatusOK, resp)
@@ -37,7 +37,7 @@ func FollowList(ctx context.Context, c *app.RequestContext) {
 
 	resp, err := rpc.UserRelationFollowList(context.Background(), &feedReq)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		return
 	}
 	c.JSON(http.StatusOK, resp)
@@ -50,7 +50,7 @@ func FollowerList(ctx context.Context, c *app.RequestContext) {
 
 	resp, err := rpc.UserRelationFollowerList(context.Background(), &feedReq)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		return
 	}
 	c.JSON(http.StatusOK, resp)
@@ -63,7 +63,7 @@ func FriendList(ctx context.Context, c *app.RequestContext) {
 
 	resp, err := rpc.UserRelationFriendList(context.Background(), &feedReq)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		return
 	}
 	c.JSON(http.StatusOK, resp)

--- a/cmd/web/controller/user.go
+++ b/cmd/web/controller/user.go
@@ -46,7 +46,7 @@ func Register(ctx context.Context, c *app.RequestContext) {
 	userRegisterReq.Password = c.Query("password")
 	resp, err := rpc.UserRegister(context.Background(), &userRegisterReq)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		c.JSON(http.StatusServiceUnavailable, err)
 	}
 	c.JSON(http.StatusOK, resp)
@@ -59,7 +59,7 @@ func Login(ctx context.Context, c *app.RequestContext) {
 
 	resp, err := rpc.UserLogin(context.Background(), &userLoginReq)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		c.JSON(http.StatusServiceUnavailable, err)
 	}
 	c.JSON(http.StatusOK, resp)
@@ -70,13 +70,13 @@ func UserInfo(ctx context.Context, c *app.RequestContext) {
 	userInfoReq.Token = c.Query("token")
 	userID, err := strconv.ParseInt(c.Query("user_id"), 10, 64)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		c.JSON(http.StatusServiceUnavailable, err)
 	}
 	userInfoReq.UserId = userID
 	resp, err := rpc.UserInfo(context.Background(), &userInfoReq)
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
 		c.JSON(http.StatusServiceUnavailable, err)
 	}
 	c.JSON(http.StatusOK, resp)

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -15,7 +15,7 @@ const (
 	UserPlatServiceName = "userplat"
 
 	WebServerPort     = "8080"
-	WebServerPublicIP = "192.168.18.106"
+	WebServerPublicIP = "192.168.0.106"
 	StaticPort        = "8081"
 
 	MySQLDefaultDSN = "tik_duck:duck@tcp(localhost:9910)/tik_duck?charset=utf8mb4&parseTime=True"


### PR DESCRIPTION
log默认输出到标准错误（stderr），每条日志前会自动加上日期和时间。如果日志不是以换行符结尾的，那么log会自动加上换行符。即每条日志会在新行中输出。

log提供了三组函数：

Print/Printf/Println：正常输出日志；
Panic/Panicf/Panicln：输出日志后，以拼装好的字符串为参数调用panic；
Fatal/Fatalf/Fatalln：输出日志后，调用os.Exit(1)退出程序。
